### PR TITLE
feat: add configuration option to select Activity Name based on currently playing track

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Based on the [Navicord](https://github.com/logixism/navicord) project.
 ## Features
 
 - Shows currently playing track with title, artist, and album art
+- Customizable activity name: "Navidrome" is default, but can be configured to display track title, artist, or album
 - Displays playback progress with start/end timestamps
 - Automatic presence clearing when track finishes
 - Multi-user support with individual Discord tokens
@@ -162,6 +163,16 @@ Access the plugin configuration in Navidrome: **Settings > Plugins > Discord Ric
   2. Create a new application or select an existing one
   3. Copy the "Application ID" from the General Information page
 - **Example**: `1234567890123456789`
+
+#### Activity Name Display
+- **What it is**: Choose what information to display as the activity name in Discord Rich Presence
+- **Options**:
+  - **Default**: Shows "Navidrome" (static app name)
+  - **Track**: Shows the currently playing track title
+  - **Album**: Shows the currently playing track's album name
+  - **Artist**: Shows the currently playing track's artist name
+- **Default**: "Default"
+- **Use case**: Choose "Track" or "Artist" for more dynamic, music-focused presence that changes with each song
 
 #### Upload to uguu.se
 - **When to enable**: Your Navidrome instance is NOT publicly accessible from the internet

--- a/main.go
+++ b/main.go
@@ -32,10 +32,10 @@ const (
 
 // Activity name display options
 const (
-	activityNameDefault = "default"
-	activityNameTitle   = "title"
-	activityNameArtist  = "artist"
-	activityNameAlbum   = "album"
+	activityNameDefault = "Default"
+	activityNameTrack   = "Track"
+	activityNameArtist  = "Artist"
+	activityNameAlbum   = "Album"
 )
 
 // userToken represents a user-token mapping from the config
@@ -149,12 +149,12 @@ func (p *discordPlugin) NowPlaying(input scrobbler.NowPlayingRequest) error {
 	activityName := "Navidrome"
 	activityNameOption, _ := pdk.GetConfig(activityNameKey)
 	switch activityNameOption {
-	case activityNameTitle:
+	case activityNameTrack:
 		activityName = input.Track.Title
-	case activityNameArtist:
-		activityName = input.Track.Artist
 	case activityNameAlbum:
 		activityName = input.Track.Album
+	case activityNameArtist:
+		activityName = input.Track.Artist
 	}
 
 	// Send activity update

--- a/main_test.go
+++ b/main_test.go
@@ -225,10 +225,10 @@ var _ = Describe("discordPlugin", func() {
 				Expect(sentPayload).To(ContainSubstring(fmt.Sprintf(`"name":"%s"`, expectedName)))
 			},
 			Entry("defaults to Navidrome when not configured", "", false, "Navidrome"),
-			Entry("defaults to Navidrome with explicit default value", "default", true, "Navidrome"),
-			Entry("uses track title when configured", "title", true, "Test Song"),
-			Entry("uses track artist when configured", "artist", true, "Test Artist"),
-			Entry("uses track album when configured", "album", true, "Test Album"),
+			Entry("defaults to Navidrome with explicit default value", "Default", true, "Navidrome"),
+			Entry("uses track title when configured", "Track", true, "Test Song"),
+			Entry("uses track album when configured", "Album", true, "Test Album"),
+			Entry("uses track artist when configured", "Artist", true, "Test Artist"),
 		)
 	})
 

--- a/manifest.json
+++ b/manifest.json
@@ -51,8 +51,8 @@
           "type": "string",
           "title": "Activity Name Display",
           "description": "Choose what to display as the activity name in Discord Rich Presence",
-          "enum": ["default", "title", "artist", "album"],
-          "default": "default"
+          "enum": ["Default", "Track", "Album", "Artist"],
+          "default": "Default"
         },
         "uguuenabled": {
           "type": "boolean",


### PR DESCRIPTION
Closes #8. The available options are `title`, `album` and `artist`.

<img width="710" height="340" alt="Untitled" src="https://github.com/user-attachments/assets/ecd6e06f-bdfa-4c3b-9191-a30032d5b1f7" />
