### PR TITLE
ci: append git SHA to manifest version in PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,13 @@ jobs:
             - name: Run tests
               run: make test
 
-            - name: Append git SHA to version
+            - name: Append PR info to version
               if: github.event_name == 'pull_request'
               run: |
+                  PR_NUM=${{ github.event.pull_request.number }}
                   SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
-                  jq --arg sha "$SHA" '.version = .version + "-" + $sha' manifest.json > manifest.tmp && mv manifest.tmp manifest.json
+                  SUFFIX="PR${PR_NUM}-${SHA}"
+                  jq --arg suffix "$SUFFIX" '.version = .version + "-" + $suffix' manifest.json > manifest.tmp && mv manifest.tmp manifest.json
 
             - name: Build and package plugin
               run: make package


### PR DESCRIPTION
## Summary
- Adds a build step that patches `manifest.json` version to `X.Y.Z-<short-sha>` for PR builds
- Only runs on `pull_request` events — push-to-main builds keep the clean release version
- Makes PR artifacts clearly distinguishable from actual releases

## Test plan
- [ ] Verify the "Append git SHA to version" step runs in this PR's own build
- [ ] Download the artifact and confirm `manifest.json` version is `0.3.0-PR14-<sha>`
- [ ] Verify push-to-main builds skip the patching step