### PR TITLE
feat: add {artists} placeholder for multi-artist activity name templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ Access the plugin configuration in Navidrome: **Settings > Plugins > Discord Ric
   - **Track**: Shows the currently playing track title
   - **Album**: Shows the currently playing track's album name
   - **Artist**: Shows the currently playing track's artist name
+  - **Custom**: Uses a template string with placeholders (see **Custom Activity Name Template** below)
+
+#### Custom Activity Name Template
+- **What it is**: A template string used when Activity Name Display is set to **Custom**
+- **Default**: `{artist} - {track}`
+- **Available placeholders**:
+  - `{track}` — The track title
+  - `{artist}` — The track's primary artist name
+  - `{artists}` — All track artists joined with ` • ` (e.g., `Borgore • Miley Cyrus`). Falls back to the value of `{artist}` when individual artist metadata is unavailable.
+  - `{album}` — The album name
 
 #### Use artwork from Cover Art Archive
 - **When to enable**: Your music is tagged with MusicBrainz IDs and you want album art from the Cover Art Archive

--- a/main.go
+++ b/main.go
@@ -267,9 +267,18 @@ func resolveActivityName(track scrobbler.TrackInfo) (string, int) {
 	case activityNameCustom:
 		template, _ := pdk.GetConfig(activityNameTemplateKey)
 		if template != "" {
+			artists := track.Artist
+			if len(track.Artists) > 0 {
+				names := make([]string, len(track.Artists))
+				for i, a := range track.Artists {
+					names[i] = a.Name
+				}
+				artists = strings.Join(names, " • ")
+			}
 			r := strings.NewReplacer(
 				"{track}", track.Title,
 				"{artist}", track.Artist,
+				"{artists}", artists,
 				"{album}", track.Album,
 			)
 			return r.Replace(template), statusDisplayName

--- a/main_test.go
+++ b/main_test.go
@@ -296,7 +296,7 @@ var _ = Describe("discordPlugin", func() {
 		)
 
 		DescribeTable("custom activity name template",
-			func(template string, templateExists bool, expectedName string) {
+			func(template string, templateExists bool, artists []scrobbler.ArtistRef, expectedName string) {
 				pdk.PDKMock.On("GetConfig", clientIDKey).Return("test-client-id", true)
 				pdk.PDKMock.On("GetConfig", usersKey).Return(`[{"username":"testuser","token":"test-token"}]`, true)
 				pdk.PDKMock.On("GetConfig", uguuEnabledKey).Return("", false)
@@ -313,16 +313,35 @@ var _ = Describe("discordPlugin", func() {
 					sentPayload = args.Get(1).(string)
 				}).Return(nil)
 
-				err := plugin.PlaybackReport(baseRequest("playing"))
+				req := baseRequest("playing")
+				req.Track.Artists = artists
+
+				err := plugin.PlaybackReport(req)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(sentPayload).To(ContainSubstring(fmt.Sprintf(`"name":"%s"`, expectedName)))
 			},
-			Entry("uses custom template with all placeholders", "{artist} - {track} ({album})", true, "Test Artist - Test Song (Test Album)"),
-			Entry("uses custom template with only track", "{track}", true, "Test Song"),
-			Entry("uses custom template with only artist", "{artist}", true, "Test Artist"),
-			Entry("uses custom template with only album", "{album}", true, "Test Album"),
-			Entry("uses custom template with plain text", "Now Playing", true, "Now Playing"),
-			Entry("falls back to Navidrome when template is empty", "", false, "Navidrome"),
+			Entry("uses custom template with all placeholders", "{artist} - {track} ({album})", true, nil, "Test Artist - Test Song (Test Album)"),
+			Entry("uses custom template with only track", "{track}", true, nil, "Test Song"),
+			Entry("uses custom template with only artist", "{artist}", true, nil, "Test Artist"),
+			Entry("uses custom template with only album", "{album}", true, nil, "Test Album"),
+			Entry("uses custom template with plain text", "Now Playing", true, nil, "Now Playing"),
+			Entry("falls back to Navidrome when template is empty", "", false, nil, "Navidrome"),
+			Entry("renders {artists} joined with bullet for multiple artists",
+				"{artists}", true,
+				[]scrobbler.ArtistRef{{Name: "Borgore"}, {Name: "Miley Cyrus"}},
+				"Borgore • Miley Cyrus"),
+			Entry("renders {artists} as single name when only one artist",
+				"{artists}", true,
+				[]scrobbler.ArtistRef{{Name: "Solo Artist"}},
+				"Solo Artist"),
+			Entry("falls back to track.Artist when Artists is empty",
+				"{artists}", true,
+				nil,
+				"Test Artist"),
+			Entry("combines {artists} with other placeholders",
+				"{artists} - {track}", true,
+				[]scrobbler.ArtistRef{{Name: "A"}, {Name: "B"}},
+				"A • B - Test Song"),
 		)
 	})
 

--- a/manifest.json
+++ b/manifest.json
@@ -65,7 +65,7 @@
         "activitynametemplate": {
           "type": "string",
           "title": "Custom Activity Name Template",
-          "description": "Template for the activity name. Available placeholders: {track}, {artist}, {album}",
+          "description": "Template for the activity name. Available placeholders: {track}, {artist}, {artists}, {album}",
           "default": "{artist} - {track}"
         },
         "caaenabled": {


### PR DESCRIPTION
## Summary

- Adds a new `{artists}` placeholder to the custom Activity Name Template.
- Renders all entries from `track.Artists` joined with ` • ` (e.g., `Borgore • Miley Cyrus`).
- Falls back to `track.Artist` when individual artist metadata is unavailable, so existing users with incomplete metadata see no regression.
- Documents the placeholder in both `manifest.json` (config UI helper text) and `README.md`.

Resolves #24 — users with multi-artist tracks can now display each contributing artist instead of the single concatenated `Artist` string.

Spec: `docs/superpowers/specs/2026-05-23-artists-placeholder-design.md`

## Test plan

- [x] Unit tests cover multi-artist join, single-artist, empty-`Artists` fallback, and `{artists}` combined with other placeholders
- [x] `make test` passes with race detector
- [x] `make build` produces `plugin.wasm` (TinyGo compatibility preserved — no new imports)
- [x] Manual smoke test: configure template `{artists} - {track}` against a multi-artist track in Navidrome and confirm the Discord activity name renders correctly