### PR TITLE
feat: add per-user track blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Based on the [Navicord](https://github.com/logixism/navicord) project.
 - Displays playback progress with start/end timestamps
 - Automatic presence clearing when playback stops
 - Multi-user support with individual Discord tokens
+- Per-user blacklist to hide specific tracks from Rich Presence
 - Optional album art from [Cover Art Archive](https://coverartarchive.org) for MusicBrainz-tagged music
 - Optional image hosting via [uguu.se](https://uguu.se) for non-public Navidrome instances
 
@@ -166,6 +167,12 @@ Add each Navidrome user who wants Discord Rich Presence. For each user, provide:
 - **Username**: The Navidrome login username (case-sensitive)
 - **Token**: The Discord user token (see Step 3 in Installation for how to obtain this)
 
+#### Blacklisted Track IDs
+- **What it is**: A per-user list of tracks to hide from Discord Rich Presence. When a blacklisted track plays, the plugin clears your presence instead of showing it.
+- **How to add**: Expand a user in the **Users** list and add one Navidrome track ID per entry.
+- **How to find a track's ID**: In Navidrome, open the track's context menu and choose **Share** — the track ID is the identifier at the end of the share link.
+- **Why track IDs**: IDs are unique to every track, so a blacklisted song is matched unambiguously — unlike a title, which two different tracks could share.
+
 ## How It Works
 
 ### Plugin Capabilities
@@ -239,6 +246,7 @@ Resolved URLs are cached (30 days for direct track links, 4 hours for search fal
 | File                             | Description                                                                         |
 |----------------------------------|-------------------------------------------------------------------------------------|
 | [main.go](main.go)               | Plugin entry point, PlaybackReport state machine, scrobbler and scheduler implementations |
+| [blacklist.go](blacklist.go)     | Per-user track blacklist matching                                                   |
 | [spotify.go](spotify.go)         | Spotify URL resolution via ListenBrainz Labs API                                    |
 | [rpc.go](rpc.go)                 | Discord gateway communication, WebSocket handling, activity management              |
 | [coverart.go](coverart.go)       | Artwork URL handling, Cover Art Archive lookups, and optional uguu.se image hosting |

--- a/blacklist.go
+++ b/blacklist.go
@@ -36,6 +36,9 @@ func userBlacklists() map[string][]string {
 // done on the Navidrome track ID, which is unique to every track.
 func isBlacklisted(username string, track scrobbler.TrackInfo) bool {
 	id := strings.TrimSpace(track.ID)
+	if id == "" {
+		return false
+	}
 	for _, item := range userBlacklists()[username] {
 		if strings.TrimSpace(item) == id {
 			return true

--- a/blacklist.go
+++ b/blacklist.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/navidrome/navidrome/plugins/pdk/go/pdk"
+	"github.com/navidrome/navidrome/plugins/pdk/go/scrobbler"
+)
+
+// userBlacklists loads the per-user track blacklists from the users config.
+// It reads the same config value as getConfig, so the two can never drift.
+func userBlacklists() map[string][]string {
+	usersJSON, ok := pdk.GetConfig(usersKey)
+	if !ok || usersJSON == "" {
+		return nil
+	}
+
+	var userTokens []userToken
+	if err := json.Unmarshal([]byte(usersJSON), &userTokens); err != nil {
+		pdk.Log(pdk.LogError, fmt.Sprintf("failed to parse users config: %v", err))
+		return nil
+	}
+
+	lists := make(map[string][]string)
+	for _, ut := range userTokens {
+		if len(ut.Blacklist) > 0 {
+			lists[ut.Username] = ut.Blacklist
+		}
+	}
+	return lists
+}
+
+// isBlacklisted reports whether a user has hidden the given track. Matching is
+// done on the Navidrome track ID, which is unique to every track.
+func isBlacklisted(username string, track scrobbler.TrackInfo) bool {
+	id := strings.TrimSpace(track.ID)
+	for _, item := range userBlacklists()[username] {
+		if strings.TrimSpace(item) == id {
+			return true
+		}
+	}
+	return false
+}

--- a/blacklist_test.go
+++ b/blacklist_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/navidrome/navidrome/plugins/pdk/go/pdk"
+	"github.com/navidrome/navidrome/plugins/pdk/go/scrobbler"
+	"github.com/stretchr/testify/mock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("isBlacklisted", func() {
+	const usersConfig = `[{"username":"user1","token":"token1","blacklist":["9O3pkfh2MhOJM1OPYJSTsh"]}]`
+
+	BeforeEach(func() {
+		pdk.ResetMock()
+		pdk.PDKMock.On("Log", mock.Anything, mock.Anything).Maybe()
+		pdk.PDKMock.On("GetConfig", usersKey).Return(usersConfig, true)
+	})
+
+	It("matches a blacklisted track by ID, ignoring stray spaces", func() {
+		track := scrobbler.TrackInfo{ID: " 9O3pkfh2MhOJM1OPYJSTsh "}
+		Expect(isBlacklisted("user1", track)).To(BeTrue())
+	})
+
+	It("does not match a track whose ID is not listed", func() {
+		track := scrobbler.TrackInfo{ID: "aB7kd0Qz1Lmn4RtuVwx2Yz"}
+		Expect(isBlacklisted("user1", track)).To(BeFalse())
+	})
+
+	It("applies the blacklist only to its own user", func() {
+		track := scrobbler.TrackInfo{ID: "9O3pkfh2MhOJM1OPYJSTsh"}
+		Expect(isBlacklisted("user2", track)).To(BeFalse())
+	})
+})

--- a/blacklist_test.go
+++ b/blacklist_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var _ = Describe("isBlacklisted", func() {
-	const usersConfig = `[{"username":"user1","token":"token1","blacklist":["9O3pkfh2MhOJM1OPYJSTsh"]}]`
+	const usersConfig = `[{"username":"user1","token":"token1","blacklist":["9O3pkfh2MhOJM1OPYJSTsh",""]}]`
 
 	BeforeEach(func() {
 		pdk.ResetMock()
@@ -31,5 +31,10 @@ var _ = Describe("isBlacklisted", func() {
 	It("applies the blacklist only to its own user", func() {
 		track := scrobbler.TrackInfo{ID: "9O3pkfh2MhOJM1OPYJSTsh"}
 		Expect(isBlacklisted("user2", track)).To(BeFalse())
+	})
+
+	It("does not blacklist a track with an empty ID", func() {
+		track := scrobbler.TrackInfo{ID: "   "}
+		Expect(isBlacklisted("user1", track)).To(BeFalse())
 	})
 })

--- a/main.go
+++ b/main.go
@@ -60,8 +60,9 @@ const (
 
 // userToken represents a user-token mapping from the config
 type userToken struct {
-	Username string `json:"username"`
-	Token    string `json:"token"`
+	Username  string   `json:"username"`
+	Token     string   `json:"token"`
+	Blacklist []string `json:"blacklist,omitempty"`
 }
 
 // discordPlugin implements the scrobbler and scheduler interfaces.
@@ -169,6 +170,16 @@ func formatRequest(input scrobbler.PlaybackReportRequest) string {
 }
 
 func (p *discordPlugin) handlePlayingOrPaused(input scrobbler.PlaybackReportRequest) error {
+	// Never expose a blacklisted track. If a previous track left a presence
+	// showing, clear it; otherwise there is nothing to do.
+	if isBlacklisted(input.Username, input.Track) {
+		pdk.Log(pdk.LogInfo, fmt.Sprintf("Track %q is blacklisted for user %s, clearing presence", input.Track.Title, input.Username))
+		if rpc.isConnected(input.Username) {
+			return rpc.clearActivity(input.Username)
+		}
+		return nil
+	}
+
 	paused := input.State == statePaused
 	pdk.Log(pdk.LogInfo, fmt.Sprintf("Setting presence for user %s, track: %s (paused=%v)", input.Username, input.Track.Title, paused))
 

--- a/manifest.json
+++ b/manifest.json
@@ -104,6 +104,14 @@
                 "title": "Discord Token",
                 "description": "The user's Discord token (keep this secret!)",
                 "minLength": 1
+              },
+              "blacklist": {
+                "type": "array",
+                "title": "Blacklisted Track IDs",
+                "description": "Navidrome track IDs to hide from Rich Presence for this user.",
+                "items": {
+                  "type": "string"
+                }
               }
             },
             "required": [
@@ -175,6 +183,10 @@
                   "options": {
                     "format": "password"
                   }
+                },
+                {
+                  "type": "Control",
+                  "scope": "#/properties/blacklist"
                 }
               ]
             }


### PR DESCRIPTION
## What
Lets each user pick specific songs to hide from their Discord Rich Presence.
When a hidden song plays, your status simply shows nothing for it, then resumes
normal operation when a non-blacklisted song plays.

## Why
Sometimes having a specific track on your public profile for everyone to see is
embarrassing or just undesirable, for one reason or another. This lets you
quietly keep those tracks off your status.

## How it works
- Each user entry gains an optional `blacklist` array of **Navidrome track IDs**.
- On a play/pause report, if the track's ID is blacklisted, the plugin skips the
  presence update. If a previous track was already showing, its presence is
  cleared so nothing lingers.
- Matching is an exact, whitespace trimmed comparison of the track ID (unique per
  track, so no ambiguity between songs that share a title).

## Configuration
Expand a user under **Users** and add one Navidrome track ID per entry under
**Blacklisted Track IDs**. The ID can be found via a track's **Share** link.

## Implementation notes
Kept the footprint on existing code minimal:
- `userToken` gains one optional `Blacklist []string` field (backward compatible;
  existing configs are unaffected).
- One guard clause at the top of `handlePlayingOrPaused`.
- All matching logic lives in a new self-contained `blacklist.go`.

## Testing
- `blacklist_test.go` covers ID matching (with whitespace trimming), non-listed
  IDs, and per-user isolation.
- `make test` passes; `make build` produces the plugin with TinyGo.